### PR TITLE
Remove delay before displaying first notification

### DIFF
--- a/dist/flare/currency/Flare-Currency.js
+++ b/dist/flare/currency/Flare-Currency.js
@@ -4778,7 +4778,6 @@ var FlareCurrencyRewardWindow = (function (_Window_Base) {
           var amountToGain = lodashFind(BattleManager._gainCurrencies, function (amount) {
             return amount.name === data[0].name;
           });
-          console.log(window._baseYForText);
           if (!lodashIsUndefined(amountToGain)) {
             this.drawText("You gained: " + amountToGain.amount + ", of: " + data[0].name, 0, window._baseYForText, 500, 'left');
             BattleManager._gainCurrencies.shift();

--- a/dist/flare/notify/Flare-NotificationWindow.js
+++ b/dist/flare/notify/Flare-NotificationWindow.js
@@ -253,18 +253,16 @@ var oldSceneMapPrototypeUpdateMainMethod = Scene_Map.prototype.updateMain;
 Scene_Map.prototype.updateMain = function () {
   oldSceneMapPrototypeUpdateMainMethod.call(this);
 
-  if (FlareNotification._getQueue().length > 0) {
+  if (this._waitForWindowToClose > 0) {
+    this._waitForWindowToClose--;
+  } else if (FlareNotification._getQueue().length > 0) {
     this.handleQueue();
   }
 };
 
 Scene_Map.prototype.handleQueue = function () {
-  if (this._waitForWindowToClose > 0) {
-    this.openFlareNotificationWindow();
-    this._waitForWindowToClose--;
-  } else {
-    this.allowAnotherWindowToBeOpened(this._flareWindow);
-  }
+  this.openFlareNotificationWindow();
+  this.allowAnotherWindowToBeOpened(this._flareWindow);
 };
 
 Scene_Map.prototype.openFlareNotificationWindow = function () {
@@ -371,7 +369,6 @@ var FlareNotificationWindow = (function (_FlareWindowBase) {
       }
 
       if (this._fadeInFinished) {
-        console.log(this._storeShowCountHalf);
         if (window._windowOptions.fadeoutTowardsBottom && this._showCount < this._storeShowCountHalf) {
 
           this.contentsOpacity -= 16;

--- a/src/add-new-currency/windows/yanfly_aftermath/flare_currency_reward_window.js
+++ b/src/add-new-currency/windows/yanfly_aftermath/flare_currency_reward_window.js
@@ -63,7 +63,6 @@ class FlareCurrencyRewardWindow extends Window_Base {
         var amountToGain = lodashFind(BattleManager._gainCurrencies, function(amount){
           return amount.name === data[0].name;
         });
-        console.log(window._baseYForText);
         if (!lodashIsUndefined(amountToGain)) {
           this.drawText("You gained: " + amountToGain.amount + ", of: " + data[0].name, 0, window._baseYForText, 500, 'left');
           BattleManager._gainCurrencies.shift();

--- a/src/add-notification-window/scene_map_update/scene_map_update.js
+++ b/src/add-notification-window/scene_map_update/scene_map_update.js
@@ -29,18 +29,16 @@ var oldSceneMapPrototypeUpdateMainMethod = Scene_Map.prototype.updateMain;
 Scene_Map.prototype.updateMain = function() {
   oldSceneMapPrototypeUpdateMainMethod.call(this);
 
-  if (FlareNotification._getQueue().length > 0 ) {
+  if (this._waitForWindowToClose > 0) {
+    this._waitForWindowToClose--;
+  } else if (FlareNotification._getQueue().length > 0) {
     this.handleQueue();
   }
 }
 
 Scene_Map.prototype.handleQueue = function() {
-  if (this._waitForWindowToClose > 0) {
-    this.openFlareNotificationWindow();
-    this._waitForWindowToClose--;
-  } else {
-    this.allowAnotherWindowToBeOpened(this._flareWindow);
-  }
+  this.openFlareNotificationWindow();
+  this.allowAnotherWindowToBeOpened(this._flareWindow);
 }
 
 Scene_Map.prototype.openFlareNotificationWindow = function() {

--- a/src/add-notification-window/windows/flare_notification_window.js
+++ b/src/add-notification-window/windows/flare_notification_window.js
@@ -67,7 +67,6 @@ class FlareNotificationWindow extends FlareWindowBase {
     }
 
     if (this._fadeInFinished) {
-      console.log(this._storeShowCountHalf);
       if (window._windowOptions.fadeoutTowardsBottom &&
           this._showCount < this._storeShowCountHalf) {
 


### PR DESCRIPTION
This patch removes the 74 frame delay before displaying the first notification, even if another notification was not recently displayed.

It also removes some console.logs